### PR TITLE
Add payload error parsing

### DIFF
--- a/src/jsonapi-datastore.js
+++ b/src/jsonapi-datastore.js
@@ -202,6 +202,16 @@ class JsonApiDataStore {
     };
   }
 
+  formatErrors(payload) {
+    return payload.errors.map(function(error) {
+      return {
+        status: error.status,
+        attribute: error.source.pointer.split('/')[3],
+        detail: error.detail
+      };
+    })
+  };
+
   /**
    * Sync a JSONAPI-compliant payload with the store.
    * @method sync
@@ -209,6 +219,10 @@ class JsonApiDataStore {
    * @return {object} The model/array of models corresponding to the payload's primary resource(s).
    */
   sync(payload) {
+    if (payload.errors) {
+      return { errors: this.formatErrors(payload) };
+    }
+
     return this.syncWithMeta(payload).data;
   }
 }

--- a/test/store.spec.js
+++ b/test/store.spec.js
@@ -206,6 +206,28 @@ describe('JsonApiDataStore', () => {
         expect(articles[1].related_article.id).to.eq(1337);
       });
     });
+
+    context('when given a payload with errors', () => {
+      var store = new JsonApiDataStore(),
+        payload = {
+          errors: [
+            {
+              status: 422,
+              source: {
+                pointer: '/data/attributes/title'
+              },
+              detail: 'is too short (minimum is 3 characters)'
+            }
+          ]
+        };
+
+      it('should return error object', () => {
+        var articleErrors = store.sync(payload).errors;
+        expect(articleErrors[0].status).to.eq(422);
+        expect(articleErrors[0].attribute).to.eq('title');
+        expect(articleErrors[0].detail).to.eq('is too short (minimum is 3 characters)');
+      });
+    });
   });
 
   describe('.syncWithMeta()', () => {


### PR DESCRIPTION
First of all thank you for this package :+1: :star: 

This is by no means ready.. Just thought it could act as a starting point for discussing how errors could be handled. 

With this approach every time a `POST` or `PATCH` response it synced the consumer must write something like this..

```js
var article = store.sync(payload);
if (article.errors) {
  // error handling
} else {
  // handle successful response
}
```

@beauby what do you think? Should errors be handled in some other way?